### PR TITLE
modinfo.json - update laptop description to include how to acquire it

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -244,7 +244,7 @@
             "author": "Jimk72",
             "version": "1.1",
             "compatibility": "All",
-            "description": "Deployable Laptop that Gives you a Options menu when you open it. Includes custom jump heights, double jump, tripple jump, and adjusts out of bounds timer as well as clear vegitation and clear all storms. Can clear cave worms, server compatible now. Turn Lights On/Off, Fire sources, and Find corpses added.",
+            "description": "Deployable Laptop that Gives you a Options menu when you open it. Includes custom jump heights, double jump, tripple jump, and adjusts out of bounds timer as well as clear vegitation and clear all storms. Can clear cave worms, server compatible now. Turn Lights On/Off, Fire sources, and Find corpses added. Found under Jimk Innovations tab in workshop.",
             "imageURL": "https://github.com/Jimk72/Icarus_Mods/raw/main/CustomOptions_Laptop.png",
             "readmeURL": "",
             "files": {


### PR DESCRIPTION
This PR:
- Updates the description for `Custom Options Laptop` so that end-users know where to acquire it.

@Jimk72, do I need to bump the version to `1.2` for just a description change?